### PR TITLE
Added .gitignore file, to ignore xcuserdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/xcuserdata/*


### PR DESCRIPTION
When adding this repo as a submodule in another project, opening in Xcode produces user-specific `xcuserdata` directories, which then cause the submodule to be marked as "dirty". This `.gitignore` file will make sure those directories are always ignored.
