### PR TITLE
Add CocoaPods support

### DIFF
--- a/CwlMachBadInstructionHandler.podspec
+++ b/CwlMachBadInstructionHandler.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = 'CwlMachBadInstructionHandler'
+  s.version      = '2.0.1'
+  s.summary      = 'TODO'
+  s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
+  s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
+  s.author       = 'Matt Gallagher'
+  s.source       = { :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git', :tag => s.version.to_s }
+  
+  s.source_files = 'Sources/CwlMachBadInstructionHandler/**/*.{h,m,c}'
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
+
+  s.swift_version = '5.0'
+end

--- a/CwlPosixPreconditionTesting.podspec
+++ b/CwlPosixPreconditionTesting.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = 'CwlPosixPreconditionTesting'
+  s.version      = '2.0.1'
+  s.summary      = 'TODO'
+  s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
+  s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
+  s.author       = 'Matt Gallagher'
+  s.source       = { :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git', :tag => s.version.to_s }
+  
+  s.source_files = 'Sources/CwlPosixPreconditionTesting/**/*.swift'
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
+
+  s.swift_version = '5.0'
+end

--- a/CwlPreconditionTesting.podspec
+++ b/CwlPreconditionTesting.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'CwlPreconditionTesting'
   s.version      = '2.0.1'
-  s.summary      = "A Mach exception handler, written in Swift and Objective-C, that allows `EXC_BAD_INSTRUCTION` (as raised by Swift's `assertionFailure`/`preconditionFailure`/`fatalError`) to be caught and tested."
+  s.summary      = "A Mach exception handler, written in Swift and Objective-C, that allows `EXC_BAD_INSTRUCTION` to be caught and tested."
   s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
   s.author       = 'Matt Gallagher'
@@ -16,16 +16,7 @@ Pod::Spec.new do |s|
   
   s.dependency 'CwlCatchException', '~> 2.0'
   s.dependency 'CwlMachBadInstructionHandler', '~> 2.0'
-
-  # s.dependency 'CwlPreconditionTesting/CwlPosixPreconditionTesting'
-
-  # s.subspec 'CwlMachBadInstructionHandler' do |ss|
-  #   ss.source_files = 'Sources/CwlMachBadInstructionHandler/**/*.{h,m,c}'    
-  # end
-
-  # s.subspec 'CwlPosixPreconditionTesting' do |ss|
-  #   ss.source_files = 'Sources/CwlPosixPreconditionTesting/**/*.swift'    
-  # end
+  s.dependency 'CwlPosixPreconditionTesting', '~> 2.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/**/*.swift'

--- a/CwlPreconditionTesting.podspec
+++ b/CwlPreconditionTesting.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |s|
+  s.name         = 'CwlPreconditionTesting'
+  s.version      = '2.0.1'
+  s.summary      = "A Mach exception handler, written in Swift and Objective-C, that allows `EXC_BAD_INSTRUCTION` (as raised by Swift's `assertionFailure`/`preconditionFailure`/`fatalError`) to be caught and tested."
+  s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
+  s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
+  s.author       = 'Matt Gallagher'
+  s.source       = { :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git', :tag => s.version.to_s }
+  
+  s.source_files = 'Sources/CwlPreconditionTesting/**/*.swift'
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
+
+  s.swift_version = '5.0'
+  
+  s.dependency 'CwlCatchException', '~> 2.0'
+  s.dependency 'CwlMachBadInstructionHandler', '~> 2.0'
+
+  # s.dependency 'CwlPreconditionTesting/CwlPosixPreconditionTesting'
+
+  # s.subspec 'CwlMachBadInstructionHandler' do |ss|
+  #   ss.source_files = 'Sources/CwlMachBadInstructionHandler/**/*.{h,m,c}'    
+  # end
+
+  # s.subspec 'CwlPosixPreconditionTesting' do |ss|
+  #   ss.source_files = 'Sources/CwlPosixPreconditionTesting/**/*.swift'    
+  # end
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+  end
+end

--- a/README.md
+++ b/README.md
@@ -10,17 +10,25 @@ For an extended discussion of this code, please see the Cocoa with Love article:
 
 ## Requirements
 
-From version 2.0.0-beta.1, building CwlPreconditionTesting requires Swift 5 or newer and the Swift Package Manager.
+From version 2.0.0-beta.1, building CwlPreconditionTesting requires Swift 5 or newer and the Swift Package Manager, or CocoaPods.
 
 For use with older versions of Swift or other package managers, [use version 1.2.0 or older](https://github.com/mattgallagher/CwlPreconditionTesting/tree/1.2.0).
 
 ## Adding to your project
+
+### Swift Package Manager
 
 Add the following to the `dependencies` array in your "Package.swift" file:
 
 	 .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: Version("2.0.0-beta.1"))
 
 Or by adding `https://github.com/mattgallagher/CwlPreconditionTesting.git`, version 2.0.0-beta.1 or later, to the list of Swift packages for any project in Xcode.
+
+### CocoaPods
+
+CocoaPods is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate CwlPreconditionTesting into your Xcode project using CocoaPods, specify it in your Podfile:
+
+pod 'CwlPreconditionTesting', '~> 2.0'
 
 ## Usage
 

--- a/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
+++ b/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-#if SWIFT_PACKAGE
+#if SWIFT_PACKAGE || COCOAPODS
 	import CwlMachBadInstructionHandler
 #endif
 

--- a/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -24,7 +24,7 @@ import CwlCatchException
 import Foundation
 import Swift
 
-#if SWIFT_PACKAGE
+#if SWIFT_PACKAGE || COCOAPODS
 	import CwlMachBadInstructionHandler
 #endif
 


### PR DESCRIPTION
cc @mattgallagher @dnkoutso 

Those will require to be published to cocoapods trunk via `pod trunk push` if this is accepted and merged.

The internal dependencies need to be pushed first before `CwlPreconditionTesting`, so they would need to be published in this order:

```bash
pod trunk push CwlMachBadInstructionHandler.podspec
pod trunk push CwlPosixPreconditionTesting.podspec
pod trunk push CwlPreconditionTesting.podspec
```

Note that this PR https://github.com/mattgallagher/CwlCatchException/pull/6 is a pre-requisite for landing this 