### PR TITLE
arm64 support

### DIFF
--- a/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m
+++ b/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m
@@ -26,15 +26,14 @@
 #import "CwlMachBadInstructionHandler.h"
 
 @protocol BadInstructionReply <NSObject>
-+(NSNumber *)receiveReply:(NSValue *)value;
++(int)receiveReply:(bad_instruction_exception_reply_t)reply;
 @end
 
 /// A basic function that receives callbacks from mach_exc_server and relays them to the Swift implemented BadInstructionException.catch_mach_exception_raise_state.
 kern_return_t catch_mach_exception_raise_state(mach_port_t exception_port, exception_type_t exception, const mach_exception_data_t code, mach_msg_type_number_t codeCnt, int *flavor, const thread_state_t old_state, mach_msg_type_number_t old_stateCnt, thread_state_t new_state, mach_msg_type_number_t *new_stateCnt) {
 	bad_instruction_exception_reply_t reply = { exception_port, exception, code, codeCnt, flavor, old_state, old_stateCnt, new_state, new_stateCnt };
 	Class badInstructionClass = NSClassFromString(@"BadInstructionException");
-	NSValue *value = [NSValue valueWithBytes: &reply objCType: @encode(bad_instruction_exception_reply_t)];
-	return [[badInstructionClass performSelector: @selector(receiveReply:) withObject: value] intValue];
+	return [badInstructionClass receiveReply:reply];
 }
 
 // The mach port should be configured so that this function is never used.

--- a/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
+++ b/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
@@ -18,7 +18,7 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-#if (os(macOS) || os(iOS)) && arch(x86_64)
+#if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
 
 import Foundation
 
@@ -26,9 +26,9 @@ import Foundation
 	import CwlMachBadInstructionHandler
 #endif
 
-private func raiseBadInstructionException() {
+var raiseBadInstructionException = {
 	BadInstructionException().raise()
-}
+} as @convention(c) () -> Void
 
 /// A simple NSException subclass. It's not required to subclass NSException (since the exception type is represented in the name) but this helps for identifying the exception through runtime type.
 @objc(BadInstructionException)
@@ -45,44 +45,45 @@ public class BadInstructionException: NSException {
 	
 	/// An Objective-C callable function, invoked from the `mach_exc_server` callback function `catch_mach_exception_raise_state` to push the `raiseBadInstructionException` function onto the stack.
 	@objc(receiveReply:)
-	public class func receiveReply(_ value: NSValue) -> NSNumber {
-		var reply = bad_instruction_exception_reply_t(exception_port: 0, exception: 0, code: nil, codeCnt: 0, flavor: nil, old_state: nil, old_stateCnt: 0, new_state: nil, new_stateCnt: nil)
-		withUnsafeMutablePointer(to: &reply) { value.getValue(UnsafeMutableRawPointer($0)) }
-		
-		let old_state: UnsafePointer<natural_t> = reply.old_state!
+	public class func receiveReply(_ reply: bad_instruction_exception_reply_t) -> CInt {
+		let old_state = UnsafeRawPointer(reply.old_state!).bindMemory(to: NativeThreadState.self, capacity: 1)
 		let old_stateCnt: mach_msg_type_number_t = reply.old_stateCnt
-		let new_state: thread_state_t = reply.new_state!
+		let new_state = UnsafeMutableRawPointer(reply.new_state!).bindMemory(to: NativeThreadState.self, capacity: 1)
 		let new_stateCnt: UnsafeMutablePointer<mach_msg_type_number_t> = reply.new_stateCnt!
 		
 		// Make sure we've been given enough memory
-		if old_stateCnt != x86_THREAD_STATE64_COUNT || new_stateCnt.pointee < x86_THREAD_STATE64_COUNT {
-			return NSNumber(value: KERN_INVALID_ARGUMENT)
-		}
+		guard old_stateCnt == nativeThreadStateCount,
+			  new_stateCnt.pointee >= nativeThreadStateCount else {
+				  return KERN_INVALID_ARGUMENT
+			  }
 		
-		// Read the old thread state
-		var state = old_state.withMemoryRebound(to: x86_thread_state64_t.self, capacity: 1) { return $0.pointee }
+		// 0. Copy over the state.
+		new_state.pointee = old_state.pointee
 		
+#if arch(x86_64)
 		// 1. Decrement the stack pointer
-		state.__rsp -= __uint64_t(MemoryLayout<Int>.size)
+		new_state.pointee.__rsp -= UInt64(MemoryLayout<Int>.size)
 		
 		// 2. Save the old Instruction Pointer to the stack.
-		if let pointer = UnsafeMutablePointer<__uint64_t>(bitPattern: UInt(state.__rsp)) {
-			pointer.pointee = state.__rip
-		} else {
-			return NSNumber(value: KERN_INVALID_ARGUMENT)
+		guard let pointer = UnsafeMutablePointer<UInt64>(bitPattern: UInt(new_state.pointee.__rsp)) else {
+			return KERN_INVALID_ARGUMENT
 		}
-		
+		pointer.pointee = old_state.pointee.__rip
+				
 		// 3. Set the Instruction Pointer to the new function's address
-		var f: @convention(c) () -> Void = raiseBadInstructionException
-		withUnsafePointer(to: &f) {
-			state.__rip = $0.withMemoryRebound(to: __uint64_t.self, capacity: 1) { return $0.pointee }
-		}
+		new_state.pointee.__rip = unsafeBitCast(raiseBadInstructionException, to: UInt64.self)
 		
-		// Write the new thread state
-		new_state.withMemoryRebound(to: x86_thread_state64_t.self, capacity: 1) { $0.pointee = state }
-		new_stateCnt.pointee = x86_THREAD_STATE64_COUNT
+#elseif arch(arm64)
+		// 1. Set the link register to the current address.
+		new_state.pointee.__lr = old_state.pointee.__pc
 		
-		return NSNumber(value: KERN_SUCCESS)
+		// 2. Set the Instruction Pointer to the new function's address.
+		new_state.pointee.__pc = unsafeBitCast(raiseBadInstructionException, to: UInt64.self)
+#endif
+
+		new_stateCnt.pointee = nativeThreadStateCount
+		
+		return KERN_SUCCESS
 	}
 }
 

--- a/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -18,7 +18,7 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-#if (os(macOS) || os(iOS)) && arch(x86_64)
+#if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
 
 import CwlCatchException
 import Foundation
@@ -182,12 +182,12 @@ public func catchBadInstruction(in block: @escaping () -> Void) -> BadInstructio
 		let currentExceptionPtr = context.currentExceptionPort
 		try kernCheck { context.withUnsafeMutablePointers { masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr in
 			// 3. Apply the mach port as the handler for this thread
-			thread_swap_exception_ports(mach_thread_self(), EXC_MASK_BAD_INSTRUCTION, currentExceptionPtr, Int32(bitPattern: UInt32(EXCEPTION_STATE) | MACH_EXCEPTION_CODES), x86_THREAD_STATE64, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
+			thread_swap_exception_ports(mach_thread_self(), nativeMachExceptionMask, currentExceptionPtr, Int32(bitPattern: UInt32(EXCEPTION_STATE) | MACH_EXCEPTION_CODES), nativeThreadState, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
 		} }
 		
 		defer { context.withUnsafeMutablePointers { masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr in
 			// 6. Unapply the mach port
-			_ = thread_swap_exception_ports(mach_thread_self(), EXC_MASK_BAD_INSTRUCTION, 0, EXCEPTION_DEFAULT, THREAD_STATE_NONE, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
+			_ = thread_swap_exception_ports(mach_thread_self(), nativeMachExceptionMask, 0, EXCEPTION_DEFAULT, THREAD_STATE_NONE, masksPtr, countPtr, portsPtr, behaviorsPtr, flavorsPtr)
 		} }
 		
 		try withUnsafeMutablePointer(to: &context) { c throws in


### PR DESCRIPTION
On arm64, Swift emits brk instructions instead which SIGTRAP rather than SIGILL. So there's a couple of changes for that, as well as various tweaks: some for correctness, and some to simplify the code.