### PR TITLE
Updated to not use the deprecated mach_port_destroy

### DIFF
--- a/CwlMachBadInstructionHandler.podspec
+++ b/CwlMachBadInstructionHandler.podspec
@@ -5,11 +5,14 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
   s.author       = 'Matt Gallagher'
-  s.source       = { :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git', :tag => s.version.to_s }
-  
+  s.source       = {
+                    :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git',
+                    :tag => s.version.to_s
+                   }
+
   s.source_files = 'Sources/CwlMachBadInstructionHandler/**/*.{h,m,c}'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.10'
 
   s.swift_version = '5.0'

--- a/CwlPosixPreconditionTesting.podspec
+++ b/CwlPosixPreconditionTesting.podspec
@@ -5,11 +5,14 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
   s.author       = 'Matt Gallagher'
-  s.source       = { :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git', :tag => s.version.to_s }
-  
+  s.source       = {
+                    :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git',
+                    :tag => s.version.to_s
+                   }
+
   s.source_files = 'Sources/CwlPosixPreconditionTesting/**/*.swift'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.10'
 
   s.swift_version = '5.0'

--- a/CwlPreconditionTesting.podspec
+++ b/CwlPreconditionTesting.podspec
@@ -5,11 +5,14 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
   s.author       = 'Matt Gallagher'
-  s.source       = { :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git', :tag => s.version.to_s }
+  s.source       = {
+                    :git => 'https://github.com/mattgallagher/CwlPreconditionTesting.git',
+                    :tag => s.version.to_s
+                   }
   
   s.source_files = 'Sources/CwlPreconditionTesting/**/*.swift'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.10'
 
   s.swift_version = '5.0'

--- a/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -171,7 +171,10 @@ public func catchBadInstruction(in block: @escaping () -> Void) -> BadInstructio
 		}
 		defer {
 			// 7. Cleanup the mach port
-			mach_port_destroy(mach_task_self_, context.currentExceptionPort)
+            // When the reference count for the right goes down to 0, it triggers the right to be deallocated
+            mach_port_mod_refs(mach_task_self_, context.currentExceptionPort, MACH_PORT_RIGHT_RECEIVE, -1)
+            // All rights deallocated, can deallocate the name/port
+            mach_port_deallocate(mach_task_self_, context.currentExceptionPort)
 		}
 		
 		try kernCheck {


### PR DESCRIPTION
Cocoapods
* Updated to set iOS 12.0 as the minimum supported version

This PR is to address Issue #29 