### PR TITLE
Add visionOS support

### DIFF
--- a/CwlMachBadInstructionHandler.podspec
+++ b/CwlMachBadInstructionHandler.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
+  s.visionos.deployment_target = '1.0'
 
   s.swift_version = '5.5'
 end

--- a/CwlPosixPreconditionTesting.podspec
+++ b/CwlPosixPreconditionTesting.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
+  s.visionos.deployment_target = '1.0'
 
   s.swift_version = '5.5'
 end

--- a/CwlPreconditionTesting.podspec
+++ b/CwlPreconditionTesting.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
+  s.visionos.deployment_target = '1.0'
 
   s.swift_version = '5.5'
   

--- a/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m
+++ b/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m
@@ -20,7 +20,7 @@
 
 #ifdef __APPLE__
 #import "TargetConditionals.h"
-#if TARGET_OS_OSX || TARGET_OS_IOS
+#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_VISION
 
 #import "mach_excServer.h"
 #import "CwlMachBadInstructionHandler.h"

--- a/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h
+++ b/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h
@@ -20,7 +20,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_OSX || TARGET_OS_IOS
+#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_VISION
 
 #import <mach/mach.h>
 

--- a/Sources/CwlMachBadInstructionHandler/mach_excServer.c
+++ b/Sources/CwlMachBadInstructionHandler/mach_excServer.c
@@ -10,7 +10,7 @@
 #define	__MIG_check__Request__mach_exc_subsystem__ 1
 
 #import "mach_excServer.h"
-#if TARGET_OS_OSX || TARGET_OS_IOS
+#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_VISION
 
 #ifndef	mig_internal
 #define	mig_internal	static __inline__

--- a/Sources/CwlMachBadInstructionHandler/mach_excServer.h
+++ b/Sources/CwlMachBadInstructionHandler/mach_excServer.h
@@ -1,6 +1,6 @@
 #ifdef __APPLE__
 #import "TargetConditionals.h"
-#if TARGET_OS_OSX || TARGET_OS_IOS
+#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_VISION
 
 #ifndef	_mach_exc_server_
 #define	_mach_exc_server_

--- a/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
+++ b/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
@@ -18,7 +18,7 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-#if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
+#if (os(macOS) || os(iOS) || os(visionOS)) && (arch(x86_64) || arch(arm64))
 
 import Foundation
 

--- a/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -18,7 +18,7 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-#if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
+#if (os(macOS) || os(iOS) || os(visionOS)) && (arch(x86_64) || arch(arm64))
 
 import CwlCatchException
 import Foundation

--- a/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift
+++ b/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift
@@ -18,7 +18,7 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-#if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
+#if (os(macOS) || os(iOS) || os(visionOS)) && (arch(x86_64) || arch(arm64))
 
 import Darwin
 

--- a/Tests/CwlPreconditionTestingTests/CwlCatchBadInstructionTests.swift
+++ b/Tests/CwlPreconditionTestingTests/CwlCatchBadInstructionTests.swift
@@ -26,7 +26,7 @@ import CwlPreconditionTesting
 
 class CatchBadInstructionTests: XCTestCase {
 	func testCatchBadInstruction() {
-	#if os(macOS) || os(iOS)
+	#if os(macOS) || os(iOS) || os(visionOS)
 		// Test catching an assertion failure
 		var reachedPoint1 = false
 		var reachedPoint2 = false


### PR DESCRIPTION
### Description
This PR combines the following PRs:
- https://github.com/mattgallagher/CwlPreconditionTesting/pull/31
- https://github.com/skumor-foreflight/CwlPreconditionTesting/pull/1

### +1
It also updates the `podspec` files to add visionOS support through CocoaPods.