### PR TITLE
Fix Carthage support

### DIFF
--- a/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
+++ b/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift
@@ -20,11 +20,11 @@
 
 #if (os(macOS) || os(iOS)) && (arch(x86_64) || arch(arm64))
 
-import CwlCatchException
 import Foundation
 import Swift
 
 #if SWIFT_PACKAGE || COCOAPODS
+	import CwlCatchException
 	import CwlMachBadInstructionHandler
 #endif
 


### PR DESCRIPTION
### Description
When using Carthage as a package manager, there are no 'Modules' after including them from source. This leads to errors if there are import statements of dependencies. In this case the `import CwlCatchException` will fail as there is no such Module.