### PR TITLE
[Issue 38] Address Xcode 16 build warnings

### DIFF
--- a/CwlMachBadInstructionHandler.podspec
+++ b/CwlMachBadInstructionHandler.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'CwlMachBadInstructionHandler'
-  s.version      = '2.2.0'
+  s.version      = '2.2.2'
   s.summary      = 'A helper for CwlPreconditionTesting implementing a Mach exception handler'
   s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }

--- a/CwlPosixPreconditionTesting.podspec
+++ b/CwlPosixPreconditionTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'CwlPosixPreconditionTesting'
-  s.version      = '2.2.0'
+  s.version      = '2.2.2'
   s.summary      = 'An alternate implementation of CwlPreconditionTesting using POSIX exceptions instead of Mach exceptions'
   s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }

--- a/CwlPreconditionTesting.podspec
+++ b/CwlPreconditionTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'CwlPreconditionTesting'
-  s.version      = '2.2.1'
+  s.version      = '2.2.2'
   s.summary      = 'A Mach exception handler, written in Swift and Objective-C, that allows `EXC_BAD_INSTRUCTION` to be caught and tested.'
   s.homepage     = 'https://github.com/mattgallagher/CwlPreconditionTesting'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
@@ -18,9 +18,9 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.5'
   
-  s.dependency 'CwlCatchException', '~> 2.2.0'
-  s.dependency 'CwlMachBadInstructionHandler', '~> 2.2.0'
-  s.dependency 'CwlPosixPreconditionTesting', '~> 2.2.0'
+  s.dependency 'CwlCatchException', '~> 2.2.1'
+  s.dependency 'CwlMachBadInstructionHandler', '~> 2.2.2'
+  s.dependency 'CwlPosixPreconditionTesting', '~> 2.2.2'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/**/*.swift'

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
 		.library(name: "CwlPosixPreconditionTesting", targets: ["CwlPosixPreconditionTesting"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/mattgallagher/CwlCatchException.git", from: "2.1.2")
+		.package(url: "https://github.com/mattgallagher/CwlCatchException.git", from: "2.2.1")
 	],
 	targets: [
 		.target(

--- a/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
+++ b/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift
@@ -32,7 +32,7 @@ var raiseBadInstructionException = {
 
 /// A simple NSException subclass. It's not required to subclass NSException (since the exception type is represented in the name) but this helps for identifying the exception through runtime type.
 @objc(BadInstructionException)
-public class BadInstructionException: NSException {
+public class BadInstructionException: NSException, @unchecked Sendable {
 	static var name: String = "com.cocoawithlove.BadInstruction"
 	
 	init() {


### PR DESCRIPTION
* Increase version to 2.2.2

Updated Dependency:
* CwlCatchException - 2.2.0 -> 2.2.1

Resolves Issue #38

Increased versions all around to match the tag (if desired, could easily ONLY increase the CwlPreconditionTesting version, but this way they all use the same tag for the same version)